### PR TITLE
Fixed executing queries.

### DIFF
--- a/YouTrack/Connection.php
+++ b/YouTrack/Connection.php
@@ -993,7 +993,7 @@ class Connection
             $params['runAs'] = (string)$runAs;
         }
 
-        $result = $this->request('POST', '/issue/' . urlencode($issue_id) . '/execute?' . http_build_query($params));
+        $result = $this->request('POST', '/issue/' . urlencode($issue_id) . '/execute', $params);
         $response = $result['response'];
         if ($response['http_code'] != 200) {
             return false;


### PR DESCRIPTION
With the existing implementation YouTrack always sent back a 413 http error when executing even a small command. The issue turned out to be sending the params on the query string, this changes the request to use $body for the params, instead of the query string.  Tested using YouTrack 6.0