### PR TITLE
Fetch issues by filter only + with comments

### DIFF
--- a/YouTrack/Connection.php
+++ b/YouTrack/Connection.php
@@ -964,6 +964,38 @@ class Connection
     }
 
     /**
+     * Get issues by filter only. Can be used to fetch issues without specifying project
+     * @link https://confluence.jetbrains.com/display/YTD6/Get+the+List+of+Issues
+     * @param string $filter
+     * @param string $after
+     * @param string $max
+     * @param string $with
+     * @return array
+     */
+    public function getIssuesByFilter($filter, $after, $max, $with = null)
+    {
+        $params = array(
+            'after' => (string)$after,
+            'max' => (string)$max,
+            'filter' => (string)$filter,
+        );
+        
+        if (isset($with))
+        {
+            $params['with'] = (string)$with;
+        }
+        
+        $this->cleanUrlParameters($params);
+        $xml = $this->get('/issue' . '?' . http_build_query($params));
+        $issues = array();
+        foreach ($xml->children() as $issue) {
+            $issues[] = new Issue(new \SimpleXMLElement($issue->asXML()), $this);
+        }
+        return $issues;
+    }
+    
+    
+    /**
      *  Apply Command to an Issue
      *
      * @link http://confluence.jetbrains.com/display/YTD5/Apply+Command+to+an+Issue

--- a/YouTrack/Issue.php
+++ b/YouTrack/Issue.php
@@ -45,7 +45,7 @@ class Issue extends Object
         foreach ($xml->children() as $nodeName=>$node) {
             if ($nodeName == 'comment')
             {
-                $this->comments[] = new Comment($node, $this->youtrack);    
+                $this->comments[] = new Comment(new \SimpleXMLElement($node->asXML()));    
                 continue;
             }
             foreach ($node->attributes() as $key => $value) {

--- a/YouTrack/Issue.php
+++ b/YouTrack/Issue.php
@@ -12,6 +12,7 @@ class Issue extends Object
 
     public function __construct(\SimpleXMLElement $xml = null, Connection $youtrack = null)
     {
+        //bug
         parent::__construct($xml, $youtrack);
         if ($xml) {
             if (!empty($this->attributes['links'])) {

--- a/YouTrack/Issue.php
+++ b/YouTrack/Issue.php
@@ -12,7 +12,6 @@ class Issue extends Object
 
     public function __construct(\SimpleXMLElement $xml = null, Connection $youtrack = null)
     {
-        //bug
         parent::__construct($xml, $youtrack);
         if ($xml) {
             if (!empty($this->attributes['links'])) {

--- a/YouTrack/Issue.php
+++ b/YouTrack/Issue.php
@@ -40,6 +40,26 @@ class Issue extends Object
         }
     }
 
+    protected function updateChildrenAttributes(\SimpleXMLElement $xml)
+    {
+        foreach ($xml->children() as $nodeName=>$node) {
+            if ($nodename == 'comment')
+            {
+                $this->comments[] = new Comment($node, $this->youtrack);    
+                continue;
+            }
+            foreach ($node->attributes() as $key => $value) {
+                if ($key == 'name') {
+                    $this->__set($value, (string)$node->value);
+                }
+                else {
+                    $this->__set($key, (string)$value);
+                }
+            }
+        }
+    }
+
+    
     /**
      * Returns the Issue Id (if it is already created or fetched)
      * @return string

--- a/YouTrack/Issue.php
+++ b/YouTrack/Issue.php
@@ -43,7 +43,7 @@ class Issue extends Object
     protected function updateChildrenAttributes(\SimpleXMLElement $xml)
     {
         foreach ($xml->children() as $nodeName=>$node) {
-            if ($nodename == 'comment')
+            if ($nodeName == 'comment')
             {
                 $this->comments[] = new Comment($node, $this->youtrack);    
                 continue;


### PR DESCRIPTION
Currently there is no method for the following API call: 
GET /rest/issue?{filter}&{with}&{max}&{after}
https://confluence.jetbrains.com/display/YTD6/Get+the+List+of+Issues

Additionally issues that contain comments are incorrectly parsed into objects, comment.id replaces issue.id 