### PR TITLE
creating new issues expects PUT request

### DIFF
--- a/YouTrack/Connection.php
+++ b/YouTrack/Connection.php
@@ -336,7 +336,7 @@ class Connection
         if (empty($body)) {
             $body = null;
         }
-        $issue = $this->requestXml('POST', '/issue?'. http_build_query($params), $body);
+        $issue = $this->requestXml('PUT', '/issue?'. http_build_query($params), $body);
         return new Issue($issue, $this);
     }
 


### PR DESCRIPTION
Creating a new issues with

$youTrack->createIssue()

results in:

Error for 'https://server/rest/issue?type=Bug&project=ST&summary=Test2015-05-1316%3A13%3A44': 413

Tested using YouTrack 6.0

The use of PUT is described here:
https://confluence.jetbrains.com/display/YTD6/Create+New+Issue