### PR TITLE
Support for other bundle types than enum

### DIFF
--- a/YouTrack/Bundle.php
+++ b/YouTrack/Bundle.php
@@ -1,0 +1,77 @@
+<?php
+namespace YouTrack;
+
+abstract class Bundle extends Object
+{
+
+    protected $values = array();
+
+    /**
+     * @var \SimpleXMLElement
+     */
+    private $elementTagName;
+
+    /**
+     * @var Connection
+     */
+    private $bundleTagName;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param string                 $elementTagName
+     * @param string                 $bundleTagName
+     * @param \SimpleXMLElement|null $xml
+     * @param Connection|null        $youtrack
+     */
+    public function __construct($elementTagName, $bundleTagName, \SimpleXMLElement $xml = null, Connection $youtrack = null)
+    {
+        $this->elementTagName = $elementTagName;
+        $this->bundleTagName = $bundleTagName;
+        parent::__construct($xml, $youtrack);
+    }
+
+    /**
+     * @param \SimpleXMLElement $xml
+     */
+    protected function update($xml)
+    {
+        $this->name = (string)$xml['name'];
+        foreach ($xml->children() as $element) {
+            $this->values[] = $this->createElement($element, $this->youtrack);
+        }
+    }
+
+    /**
+     * @return BundleElement[]
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    /**
+     * @param \SimpleXMLElement $xml
+     * @param Connection|null   $youtrack
+     *
+     * @return mixed
+     */
+    abstract protected function createElement(\SimpleXMLElement $xml, Connection $youtrack = null);
+
+    /**
+     * @return string
+     */
+    public function toXml()
+    {
+        $xml = sprintf('<%s name="%s">', $this->bundleTagName, utf8_encode($this->name));
+        foreach ($this->values as $v) {
+            $xml .= '<value>'. $v .'</value>';
+        }
+        $xml .= sprintf('</%s>', $this->bundleTagName);
+
+        return $xml;
+    }
+}

--- a/YouTrack/BundleElement.php
+++ b/YouTrack/BundleElement.php
@@ -1,0 +1,79 @@
+<?php
+namespace YouTrack;
+
+abstract class BundleElement extends Object
+{
+
+    /**
+     * @var \SimpleXMLElement
+     */
+    private $elementTagName;
+
+    /** @var string */
+    private $name;
+
+    /** @var string */
+    private $description;
+
+    /** @var int */
+    private $colorIndex;
+
+    /**
+     * @param string                 $elementTagName
+     * @param \SimpleXMLElement|null $xml
+     * @param Connection|null        $youtrack
+     */
+    public function __construct($elementTagName, \SimpleXMLElement $xml = null, Connection $youtrack = null)
+    {
+        parent::__construct($xml, $youtrack);
+        $this->elementTagName = $elementTagName;
+    }
+
+    /**
+     * @param \SimpleXMLElement $xml
+     */
+    protected function update($xml)
+    {
+        $this->name = (string)$xml;
+        $this->description = (string)$xml['description'];
+        $this->colorIndex = (int)$xml['colorIndex'];
+
+        $this->updateSpecificAttributes($xml);
+    }
+
+    /**
+     * @param \SimpleXMLElement $xml
+     */
+    protected function updateSpecificAttributes(\SimpleXMLElement $xml)
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return int
+     */
+    public function getColorIndex()
+    {
+        return $this->colorIndex;
+    }
+
+    public function __toString()
+    {
+        return (string)$this->name;
+    }
+}

--- a/YouTrack/Connection.php
+++ b/YouTrack/Connection.php
@@ -20,6 +20,15 @@ class Connection
     private $user_agent = 'Mozilla/5.0'; // Use this as user agent string.
     private $verify_ssl = false;
 
+    private $bundle_paths  = array(
+        'ownedField' => 'ownedFieldBundle',
+        'enum'       => 'bundle',
+        /*'build'      => 'buildBundle',
+        'state'      => 'stateBundle',
+        'version'    => 'versionBundle',
+        'user'       => 'userBundle'*/
+    );
+
     /**
      * @var bool
      */
@@ -1139,12 +1148,54 @@ class Connection
     }
 
     /**
+     * @param $fieldType
+     * @param $name
+     *
+     * @return Bundle
+     * @throws \Exception
+     */
+    public function getBundle($fieldType, $name)
+    {
+        $fieldType = $this->getFieldType($fieldType);
+
+        $className= 'YouTrack\\' . ucfirst($fieldType) . 'Bundle';
+
+        $bundlePath = null;
+        if (isset($this->bundle_paths[$fieldType])) {
+            $bundlePath = $this->bundle_paths[$fieldType];
+        }
+
+        if (!$bundlePath) {
+            throw new \Exception('Unknown bundle field type');
+        }
+
+        return new $className(
+            $this->get(sprintf('/admin/customfield/%s/%s', $bundlePath, rawurlencode($name))),
+            $this
+        );
+    }
+
+    /**
+     * @param $fieldType
+     *
+     * @return string
+     */
+    public function getFieldType($fieldType)
+    {
+        if (false !== strpos($fieldType, '[')) {
+            return substr($fieldType, 0, -3);
+        }
+
+        return $fieldType;
+    }
+
+    /**
      * @param string $name
      * @return EnumBundle
      */
     public function getEnumBundle($name)
     {
-        return new EnumBundle($this->get('/admin/customfield/bundle/' . rawurlencode($name)), $this);
+        return $this->getBundle('enum', $name);
     }
 
     /**

--- a/YouTrack/EnumBundle.php
+++ b/YouTrack/EnumBundle.php
@@ -1,43 +1,26 @@
 <?php
 namespace YouTrack;
 
-/**
- *
- * @author Jens Jahnke <jan0sch@gmx.net>
- * @author Nepomuk Frädrich <info@nepda.eu>
- * Created at: 29.03.11 16:29
- */
+class EnumBundle extends Bundle
+{
 
-
-class EnumBundle extends Object {
-  private $name = '';
-  private $values = array();
-
-  public function __construct(\SimpleXMLElement $xml = null, Connection $youtrack = null) {
-    parent::__construct($xml, $youtrack);
-  }
-
-  protected function updateAttributes(\SimpleXMLElement $xml) {
-    $this->name = (string)$xml->attributes()->name;
-  }
-
-  protected function updateChildrenAttributes(\SimpleXMLElement $xml) {
-    foreach ($xml->children() as $node) {
-      $this->values[] = (string)$node;
+    /**
+     * @param \SimpleXMLElement|null $xml
+     * @param Connection|null        $youtrack
+     */
+    public function __construct(\SimpleXMLElement $xml = null, Connection $youtrack = null)
+    {
+        parent::__construct('value', 'enumeration', $xml, $youtrack);
     }
-  }
 
-  public function toXML() {
-    $xml = '<enumeration name="'. $this->name .'">';
-    foreach ($this->values as $v) {
-      $xml .= '<value>'. $v .'</value>';
+    /**
+     * @param \SimpleXMLElement $xml
+     * @param Connection|null   $youtrack
+     *
+     * @return OwnedField
+     */
+    protected function createElement(\SimpleXMLElement $xml, Connection $youtrack = null)
+    {
+        return new EnumField($xml, $youtrack);
     }
-    $xml .= '</enumeration>';
-
-    return $xml;
-  }
-
-  public function getValues() {
-    return $this->values;
-  }
 }

--- a/YouTrack/EnumField.php
+++ b/YouTrack/EnumField.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace YouTrack;
+
+class EnumField extends BundleElement
+{
+
+    /**
+     * @param \SimpleXMLElement|null $xml
+     * @param Connection|null        $youtrack
+     */
+    public function __construct(\SimpleXMLElement $xml = null, Connection $youtrack = null)
+    {
+        parent::__construct('value', $xml, $youtrack);
+    }
+}

--- a/YouTrack/Object.php
+++ b/YouTrack/Object.php
@@ -19,9 +19,8 @@ class Object {
     public function __construct(\SimpleXMLElement $xml = null, Connection $youtrack = null)
     {
         $this->youtrack = $youtrack;
-        if ($xml) {
-            $this->updateAttributes($xml);
-            $this->updateChildrenAttributes($xml);
+        if ($xml !== null) {
+            $this->update($xml);
         }
     }
 
@@ -36,6 +35,12 @@ class Object {
     public function __set($name, $value)
     {
         $this->attributes["$name"] = $value;
+    }
+
+    protected function update($xml)
+    {
+        $this->updateAttributes($xml);
+        $this->updateChildrenAttributes($xml);
     }
 
     protected function updateAttributes(\SimpleXMLElement $xml)

--- a/YouTrack/OwnedField.php
+++ b/YouTrack/OwnedField.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace YouTrack;
+
+class OwnedField extends BundleElement
+{
+
+    /** @var string */
+    private $owner;
+
+    /**
+     * @param \SimpleXMLElement|null $xml
+     * @param Connection|null        $youtrack
+     */
+    public function __construct(\SimpleXMLElement $xml = null, Connection $youtrack = null)
+    {
+        parent::__construct('ownedField', $xml, $youtrack);
+    }
+
+    /**
+     * @param \SimpleXMLElement $xml
+     */
+    protected function updateSpecificAttributes(\SimpleXMLElement $xml)
+    {
+        $this->owner = (string)$xml['owner'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getOwner()
+    {
+        return $this->owner;
+    }
+}

--- a/YouTrack/OwnedFieldBundle.php
+++ b/YouTrack/OwnedFieldBundle.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace YouTrack;
+
+class OwnedFieldBundle extends Bundle
+{
+
+    /**
+     * @param \SimpleXMLElement|null $xml
+     * @param Connection|null        $youtrack
+     */
+    public function __construct(\SimpleXMLElement $xml = null, Connection $youtrack = null)
+    {
+        parent::__construct('ownedField', 'ownedFieldBundle', $xml, $youtrack);
+    }
+
+    /**
+     * @param \SimpleXMLElement $xml
+     * @param Connection|null   $youtrack
+     *
+     * @return OwnedField
+     */
+    protected function createElement(\SimpleXMLElement $xml, Connection $youtrack = null)
+    {
+        return new OwnedField($xml, $youtrack);
+    }
+}

--- a/test/ConnectionTest.php
+++ b/test/ConnectionTest.php
@@ -30,4 +30,12 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\YouTrack\IncorrectLoginException');
         $method->invoke($con, $content, $response);
     }
+
+    public function testGetFieldType()
+    {
+        $con = new TestConnection();
+
+        $this->assertEquals('ownedField', $con->getFieldType('ownedField[1]'));
+        $this->assertEquals('ownedField', $con->getFieldType('ownedField'));
+    }
 }

--- a/test/EnumFieldTest.php
+++ b/test/EnumFieldTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace YouTrack;
+
+class EnumFieldTest extends \PHPUnit_Framework_TestCase
+{
+
+    private $filename = 'test/testdata/enum_bundle.xml';
+
+    public function testGetOwnedFieldBundleElements()
+    {
+        $xml = simplexml_load_file($this->filename);
+        $bundle = new EnumBundle($xml);
+
+        /** @var EnumField[] $bundleElements */
+        $bundleElements = $bundle->getValues();
+
+        $this->assertCount(3, $bundleElements);
+
+        $this->assertSame('V1', $bundleElements[0]->getName());
+        $this->assertSame('V1', (string)$bundleElements[0]);
+
+    }
+}

--- a/test/OwnedFieldBundleTest.php
+++ b/test/OwnedFieldBundleTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace YouTrack;
+
+class OwnedFieldBundleTest extends \PHPUnit_Framework_TestCase
+{
+
+    private $filename = 'test/testdata/owned_field_bundle.xml';
+
+    public function testGetOwnedFieldBundleElements()
+    {
+        $xml = simplexml_load_file($this->filename);
+        $bundle = new OwnedFieldBundle($xml);
+
+        /** @var OwnedField[] $bundleElements */
+        $bundleElements = $bundle->getValues();
+
+        $this->assertCount(3, $bundleElements);
+
+        $this->assertSame('Test', $bundleElements[0]->getName());
+        $this->assertSame(4, $bundleElements[0]->getColorIndex());
+        $this->assertSame('', $bundleElements[0]->getDescription());
+        $this->assertSame('<no user>', $bundleElements[0]->getOwner());
+
+        $this->assertSame('TestWithOwner', $bundleElements[1]->getName());
+        $this->assertSame(4, $bundleElements[1]->getColorIndex());
+        $this->assertSame('', $bundleElements[1]->getDescription());
+        $this->assertSame('userX', $bundleElements[1]->getOwner());
+
+        $this->assertSame('TestWitDescription', $bundleElements[2]->getName());
+        $this->assertSame(1, $bundleElements[2]->getColorIndex());
+        $this->assertSame('Test', $bundleElements[2]->getDescription());
+        $this->assertSame('<no user>', $bundleElements[2]->getOwner());
+    }
+}

--- a/test/testdata/enum_bundle.xml
+++ b/test/testdata/enum_bundle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<enumeration name="enumTestBundle">
+    <value>V1</value>
+    <value>V2</value>
+    <value>V3</value>
+</enumeration>

--- a/test/testdata/owned_field_bundle.xml
+++ b/test/testdata/owned_field_bundle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ownedFieldBundle name="KS: Subsystems">
+    <ownedField owner="&lt;no user&gt;" colorIndex="4">Test</ownedField>
+    <ownedField owner="userX" colorIndex="4">TestWithOwner</ownedField>
+    <ownedField description="Test" owner="&lt;no user&gt;" colorIndex="1">TestWitDescription</ownedField>
+</ownedFieldBundle>


### PR DESCRIPTION
Support for OwnedFieldBundles would be great.

There is already an implementation for the EnumBundle in Connection.php.

Beside implementing the OwnedFieldBundle support, i tried to refactor the EnumBundle implementation.

This could be extended for the remaining bundle types:
Build Bundles
State Bundles
Version Bundles
User Bundles

Would be great to hear your feedback on the impementation and if it breaks the EnumBundle ;-). We only use OwnedFieldBundle so far, so testing of EnumBundle was limited.