### PR TITLE
new methods for test existence of comments, attachments, links

### DIFF
--- a/YouTrack/Issue.php
+++ b/YouTrack/Issue.php
@@ -111,6 +111,14 @@ class Issue extends Object
     }
 
     /**
+     * @return bool
+     */
+    public function hasComments()
+    {
+        return count($this->comments) > 0;
+    }
+
+    /**
      * @return array|Attachment[]
      */
     public function getAttachments()
@@ -122,6 +130,14 @@ class Issue extends Object
     }
 
     /**
+     * @return bool
+     */
+    public function hasAttachments()
+    {
+        return count($this->attachments) > 0;
+    }
+
+    /**
      * @return Link[]
      */
     public function getLinks()
@@ -130,5 +146,13 @@ class Issue extends Object
             $this->links = $this->youtrack->getLinks($this->__get('id'));
         }
         return $this->links;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasLinks()
+    {
+        return count($this->links) > 0;
     }
 }


### PR DESCRIPTION
Let's say we have 10 Issues with no comments. When we retrieve these issues from YouTrack

    $youTrack = new \YouTrack\Connection('...');
    $issues = $youTrack->getIssuesByFilter('some filter');
    foreach ($issues as $issue) {
      $issue->getComments();
    }

the method `getIssuesByFilter` does one API-call, but inside `getComments` we do another API-call for each issue. 1 + 10, but we only need 1 if we already know there are no comments.

    $youTrack = new \YouTrack\Connection('...');
    $issues = $youTrack->getIssuesByFilter('some filter');
    foreach ($issues as $issue) {
      if ($issue->hasComments()) {
        $issue->getComments();
      }
    }