### PR TITLE
Get PHP 5.4 support back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 php:
   - 7.0
   - 5.6
+  - 5.5
+  - 5.4
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
         }
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=5.4",
         "ext-json": ">=1",
         "lib-curl": ">=7"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*",
+        "phpunit/phpunit": "4.*",
         "phpunit/php-invoker": "*",
         "phpunit/dbunit": ">=1.2",
         "phpunit/phpunit-selenium": ">=1.2",

--- a/test/ConnectionTest.php
+++ b/test/ConnectionTest.php
@@ -15,7 +15,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
     public function testCreateConnection()
     {
         $con = new TestConnection();
-        $this->assertInstanceOf(TestConnection::class, $con);
+        $this->assertInstanceOf('\YouTrack\TestConnection', $con);
     }
 
     public function testIncorrectLoginThrowsException()


### PR DESCRIPTION
I wonder why my PhpStorm changed all the line encoding though.