### PR TITLE
Error getting login of the author of WorkItem

### DIFF
--- a/YouTrack/Workitem.php
+++ b/YouTrack/Workitem.php
@@ -35,7 +35,7 @@ class Workitem extends Object
 
         if (isset($xml->author)) {
             $this->attributes['author'] = new User(null, $youtrack);
-            $this->attributes['author']->__set('login', (string)$xml->author);
+            $this->attributes['author']->__set('login', (string)$xml->author['login']);
         }
     }
 


### PR DESCRIPTION
When you receive workitems, author's attribute "login" is NULL. Fix it.